### PR TITLE
fix: api docs link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,6 @@
 - View the paymentMethod.id in the alert or the console.
 
 # What's Next?
-[API Docs](api.tilled.com/docs)
+[API Docs](https://docs.tilled.com/api)
 
 You can try out attaching payment methods to customers, adding metadata, including platform fees on payment intents and much, much more via the Tilled API.


### PR DESCRIPTION
Currently the README.md `API Docs` url [does not work](https://github.com/gettilled/simple-payment-example/blob/main/README.md?plain=1#L39). Looks like GitHub [doesn't interpret the location provided as a web url](api.tilled.com/docs), thus it thinks the link is to a location relative in the project and results in a 404.

This small change simply updates the `API Docs` url line in README.md so the link now works. It links to the new docs location to avoid redirects (a la api.tilled.com).

I tested this [here](https://gist.github.com/davidnuzik/b55e2b37531bd3153fb476f4404b721c) (last link) and on my fork [here](https://github.com/davidnuzik/simple-payment-example/blob/nuzik-fix-readme-api-docs-link/README.md) and confirmed it should work as expected.

Signed-off-by: David Nuzik <david.nuzik@gmail.com>